### PR TITLE
Update deprecated warning - boundingrectwithsize:options:attributes:cont...

### DIFF
--- a/TWSatatusExample/TWStatus/TWStatus.m
+++ b/TWSatatusExample/TWStatus/TWStatus.m
@@ -201,7 +201,15 @@
 
 - (void)layout{
     
-    CGSize size = [_status sizeWithFont:_statusLabel.font forWidth:320 lineBreakMode:_statusLabel.lineBreakMode];
+    NSAttributedString *attributedText = [[NSAttributedString alloc]
+                                          initWithString:_statusLabel.text attributes:@ {
+                                            NSFontAttributeName: _statusLabel.font
+                                          }];
+
+    CGRect rect = [attributedText boundingRectWithSize:(CGSize){320, CGFLOAT_MAX}
+                                               options:NSStringDrawingUsesLineFragmentOrigin
+                                               context:nil];
+    CGSize size = rect.size;
  
     CGRect statusLabelFrame = _statusLabel.frame;
     statusLabelFrame.size.width = size.width;


### PR DESCRIPTION
Fixes the deprecation warning for iOS7 (removes `sizeWithFont:forWidth:lineBreakMode:`)

Update method to: `boundingRectWithSize:options:attributes:context:`
