### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Status with ``` UIActivityIndicator ```
 
 Plain status
 
-##Installation
+## Installation
 Copy contents of the 'TWStatus' folder to your project
 
-##Usage
+## Usage
 
 ```objc
 //Show status with activity indicator
@@ -31,7 +31,7 @@ Copy contents of the 'TWStatus' folder to your project
 
 ```
 
-##Requirements
+## Requirements
 - iOS >= 5.0
 - ARC
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
